### PR TITLE
Allow to pass float temperature into quickShower API.

### DIFF
--- a/kohler/kohler.py
+++ b/kohler/kohler.py
@@ -189,10 +189,10 @@ class Kohler:
             "valve_num": valve_num,
             "valve1_outlet": valve1_outlet,
             "valve1_massage": valve1_massage,
-            "valve1_temp": valve1_temp,
+            "valve1_temp": f"{int(valve1_temp)}.0",
             "valve2_outlet": valve2_outlet,
             "valve2_massage": valve2_massage,
-            "valve2_temp": valve2_temp
+            "valve2_temp": f"{int(valve2_temp)}.0"
         }
         url = f"{self._baseUrl}/quick_shower.cgi"
         return self.fetch(url, params, CONTENT_TYPE_TEXT_PLAIN, 3)


### PR DESCRIPTION
Motivation: homeassistant uses float temperature and may convert between C and F, which can result in long mantissa, such as 17.2222222222. My kohler device chokes on long mantissa ignoring the command completely.

While I see kohler UI to be only using int temperatures, I decided against specifying 'int' as a parameter type for 2 reasons:
- backwards compatibility
- home assistant uses 'float'

Should we add an assert to check that temperature params are either 'int' or 'float' ?